### PR TITLE
add timeline-panel component

### DIFF
--- a/app/css/blocks/timeline-panel.postcss.css
+++ b/app/css/blocks/timeline-panel.postcss.css
@@ -1,0 +1,14 @@
+@import '../assets/globals.postcss.css';
+
+.timeline-panel {
+  position: relative;
+  top: -20*$PX;
+  background: #$c-light-purple;
+  box-shadow: 0 2*$PX 4*$PX black;
+  height: 22*$PX;
+}
+
+.label {
+  font-family: Arial;
+  fill: $c-white;
+}

--- a/app/css/blocks/timeline-panel.postcss.css.json
+++ b/app/css/blocks/timeline-panel.postcss.css.json
@@ -1,0 +1,1 @@
+{"timeline-panel":"_timeline-panel_112zt_3","label":"_label_112zt_11"}

--- a/app/js/components/main-panel/right-panel.babel.jsx
+++ b/app/js/components/main-panel/right-panel.babel.jsx
@@ -3,6 +3,7 @@ import { bind } from 'decko';
 
 import HideButton from '../hide-button';
 import ResizeHandle from '../resize-handle';
+import TimelinePanel from '../timeline-panel';
 
 const CLASSES = require('../../../css/blocks/right-panel.postcss.css.json');
 require('../../../css/blocks/right-panel');
@@ -14,6 +15,7 @@ class RightPanel extends Component {
       <div className={CLASSES['right-panel']}>
         <HideButton isHidden={state.isHidden} onTap={this._onHideButton} />
         <ResizeHandle {...this.props} />
+        <TimelinePanel time={12} />
       </div>
     );
   }

--- a/app/js/components/timeline-panel.babel.jsx
+++ b/app/js/components/timeline-panel.babel.jsx
@@ -1,0 +1,101 @@
+import { h, Component } from 'preact';
+import { bind } from 'decko';
+
+import C from '../constants';
+
+const CLASSES = require('../../css/blocks/timeline-panel.postcss.css.json');
+require('../../css/blocks/timeline-panel');
+
+class TimelinePanel extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      rootFontSize: 5, //px
+      scale: props.scale || 1,
+      dashesPerSec: 20
+    }
+
+    let {scale, rootFontSize} = this.state;
+    this._dashesAmount = props.time * this.state.dashesPerSec;
+  }
+
+  render () {
+    return (
+      <div className={CLASSES['timeline-panel']}>
+        { this._timeline }
+      </div>
+    );
+  }
+
+  componentWillMount() {
+    this._timeline = this._createTimeline();
+  }
+
+  @bind
+  _createTimeline() {
+    const dashes = this._compileDashes();
+    const pointerValues = this._compileLabels();
+    const {rootFontSize} = this.state;
+
+    let timeline = (
+      <svg width="100%" height={C.TIMELINE_HEIGHT}>
+        <g style={{'font-size': rootFontSize}}>
+          {dashes}
+          {pointerValues}
+        </g>
+      </svg>
+    );
+    return timeline;
+  }
+
+  @bind
+  _createDash(dashNumber) {
+    const {dashesPerSec, scale} = this.state;
+    const dashType = (!(dashNumber % (dashesPerSec / 2)) || dashNumber === 0) ? 'large' :
+                     !(dashNumber % (dashesPerSec / 4)) ? 'middle' : 'small';
+
+    const color = dashType === 'large' ? '#fff' : '#ae9bae';
+    const height = dashType === 'large' ? 7 : (dashType === 'middle') ? 6 : 4;
+    const xPos = scale * dashNumber;
+    const yPos = C.TIMELINE_HEIGHT - height;
+
+    return (
+      <g>
+        <rect width="1" height={height} x={`${xPos}em`} y={yPos} fill={color}/>
+      </g>
+    );
+  }
+
+  _compileDashes() {
+    let dashes = [];
+    for (let j = 0; j <= this._dashesAmount; j++) {
+      dashes.push(this._createDash(j, C.TIMELINE_HEIGHT));
+    }
+
+    return dashes;
+  };
+
+  _compileLabels() {
+    let labels = [];
+    const {dashesPerSec, scale, rootFontSize} = this.state;
+
+    for (let j = 0, value = 0; j <= this._dashesAmount; j += dashesPerSec/2, value += 500) {
+      const textAnchor = j === 0 ? 'start' : 'middle';
+      const xPos = scale * rootFontSize * j;
+      const yPos = C.TIMELINE_HEIGHT / 2;
+      const className = CLASSES['label'];
+
+      labels.push(
+        <text x={xPos} y={yPos} text-anchor={textAnchor} className={className}
+          style={{'font-size': `${1.4 * scale}em`}}>
+          {value}
+        </text>
+      );
+    }
+
+    return labels;
+  }
+}
+
+export default TimelinePanel;

--- a/app/js/constants.babel.js
+++ b/app/js/constants.babel.js
@@ -4,5 +4,6 @@
 export default {
   NAME:               'MOJS_TIMLINE_EDITOR_Hjs891ksPP',
   IS_PERSIST_STATE:   true,
-  PLAYER_HEIGHT:      40
+  PLAYER_HEIGHT:      40,
+  TIMELINE_HEIGHT:    22
 };


### PR DESCRIPTION
Created timeline component using svg and avoided using em as units.

You can pass scale as props of timeline component and everything works properly, so I might miss the thing with reference to 'em' units, but wasn't sure how to mix it with svg so maybe this solution will be ok.